### PR TITLE
Add tests to makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.pytest_cache*
+__pycache__*

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - "pip install --upgrade logilab-common"
   - "pip install --upgrade pytest"
 script:
-  - pytest ./test.py;
+  - make check;
 before_deploy:
   - sudo apt-get update -qy
   - sudo apt-get install -qy python3 python3-pip

--- a/Makefile
+++ b/Makefile
@@ -21,3 +21,6 @@ uninstall:
 	rm -f $(BINDIR)/pdd
 	rm -f $(MANDIR)/pdd.1.gz
 	rm -rf $(DOCDIR)
+
+check:
+	@python3 -m pytest test.py


### PR DESCRIPTION
Distros like Void Linux has [code](https://github.com/voidlinux/void-packages/blob/master/common/build-style/gnu-makefile.sh#L18) to automatically run `make check` when installing via makefiles, gnu-autoconf, cmake and others, add a check target to automate that away.

example:
```
$ make check
============================= test session starts ==============================
platform linux -- Python 3.6.5, pytest-3.5.0, py-1.5.3, pluggy-0.6.0
rootdir: /home/terran/src/pdd, inifile:
plugins: hypothesis-3.49.1
collected 15 items

test.py ...............                                                  [100%]

========================== 15 passed in 0.67 seconds ===========================
```

we also adapt .travis.yml to use it