### PR TITLE
Include tests in sdist tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include CHANGELOG LICENSE
+include test.py


### PR DESCRIPTION
This allows vendors to sanity-check the package with their python stack when they download the package from pypi.