### PR TITLE
Add openSUSE Tumbleweed to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 <a href="https://packages.debian.org/search?keywords=pdd&searchon=names&exact=1"><img src="https://img.shields.io/badge/debian-10+-blue.svg?maxAge=2592000" alt="Debian Buster+" /></a>
 <a href="https://apps.fedoraproject.org/packages/pdd"><img src="https://img.shields.io/badge/fedora-27+-blue.svg?maxAge=2592000" alt="Fedora 27+" /></a>
 <a href="https://packages.ubuntu.com/search?keywords=pdd&searchon=names&exact=1"><img src="https://img.shields.io/badge/ubuntu-18.04+-blue.svg?maxAge=2592000" alt="Ubuntu Bionic+" /></a>
+<a href="https://software.opensuse.org/package/python3-pdd"><img src="https://img.shields.io/badge/openSUSE-Tumbleweed-blue.svg?maxAge=2592000" alt="openSUSE Tumbleweed" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
`pdd` is now included in openSUSE Tumbleweed.

The package is `python3-pdd`, which is following openSUSE naming convention for Python packages.