### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
-language = "python"
+language = "python3"
 run = "./pdd -h"

--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "bash"
+run = "./pdd -h"

--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
-language = "bash"
+language = "python"
 run = "./pdd -h"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 <a href="https://apps.fedoraproject.org/packages/pdd"><img src="https://img.shields.io/badge/fedora-27+-blue.svg?maxAge=2592000" alt="Fedora 27+" /></a>
 <a href="https://software.opensuse.org/package/python3-pdd"><img src="https://img.shields.io/badge/opensuse-tumbleweed-blue.svg?maxAge=2592000" alt="openSUSE Tumbleweed" /></a>
 <a href="https://packages.ubuntu.com/search?keywords=pdd&searchon=names&exact=1"><img src="https://img.shields.io/badge/ubuntu-18.04+-blue.svg?maxAge=2592000" alt="Ubuntu Bionic+" /></a>
+<a href="https://repl.it/badge/github/jarun/pdd"><img src="https://repl.it/badge/github/jarun/pdd?maxAge=2592000" alt="openSUSE Tumbleweed" /></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <a href="https://apps.fedoraproject.org/packages/pdd"><img src="https://img.shields.io/badge/fedora-27+-blue.svg?maxAge=2592000" alt="Fedora 27+" /></a>
 <a href="https://software.opensuse.org/package/python3-pdd"><img src="https://img.shields.io/badge/opensuse-tumbleweed-blue.svg?maxAge=2592000" alt="openSUSE Tumbleweed" /></a>
 <a href="https://packages.ubuntu.com/search?keywords=pdd&searchon=names&exact=1"><img src="https://img.shields.io/badge/ubuntu-18.04+-blue.svg?maxAge=2592000" alt="Ubuntu Bionic+" /></a>
-<a href="https://repl.it/badge/github/jarun/pdd"><img src="https://repl.it/badge/github/jarun/pdd?maxAge=2592000" alt="openSUSE Tumbleweed" /></a>
+<a href="https://repl.it/badge/github/jarun/pdd"><img src="https://repl.it/badge/github/jarun/pdd?maxAge=2592000" alt="Repl.it" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.It adds a `.replit` configuration file and a Repl.it badge to the `README`. This will allow viewers of the repository to click the run on Repl.it button and be able to use ddgr inside the Repl.it environment.
You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Mosrod/pdd).