### PR TITLE
fix run on repl.it badge

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,2 +1,2 @@
 language = "python3"
-run = "./pdd -h"
+run = "chmod +x pdd && ./pdd -h"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <a href="https://apps.fedoraproject.org/packages/pdd"><img src="https://img.shields.io/badge/fedora-27+-blue.svg?maxAge=2592000" alt="Fedora 27+" /></a>
 <a href="https://software.opensuse.org/package/python3-pdd"><img src="https://img.shields.io/badge/opensuse-tumbleweed-blue.svg?maxAge=2592000" alt="openSUSE Tumbleweed" /></a>
 <a href="https://packages.ubuntu.com/search?keywords=pdd&searchon=names&exact=1"><img src="https://img.shields.io/badge/ubuntu-18.04+-blue.svg?maxAge=2592000" alt="Ubuntu Bionic+" /></a>
-<a href="https://repl.it/badge/github/jarun/pdd"><img src="https://repl.it/badge/github/jarun/pdd?maxAge=2592000" alt="Repl.it" /></a>
+<a href="https://repl.it/github/jarun/pdd"><img src="https://repl.it/badge/github/jarun/pdd?maxAge=2592000" alt="Repl.it" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
1. gives repl permission to execute the file
2. points to the badge to repl.it instead of the badge image source. 