### PR TITLE
Fix #23

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,13 @@ BINDIR ?= $(DESTDIR)$(PREFIX)/bin
 MANDIR ?= $(DESTDIR)$(PREFIX)/share/man/man1
 DOCDIR ?= $(DESTDIR)$(PREFIX)/share/doc/pdd
 
-.PHONY: all install uninstall
+.PHONY: all install uninstall install-bin install-completions install-bash-completion install-zsh-completion install-fish-completion
 
 all:
 
-install:
+install: install-bin install-completions
+
+install-bin:
 	install -m755 -d $(BINDIR)
 	install -m755 -d $(MANDIR)
 	install -m755 -d $(DOCDIR)
@@ -17,10 +19,26 @@ install:
 	install -m644 README.md $(DOCDIR)
 	rm -f pdd.1.gz
 
+install-completions: install-bash-completion install-zsh-completion install-fish-completion
+
+install-bash-completion:
+	install -m644 auto-completion/bash/pdd.bash $(PREFIX)/share/bash-completion/compilations/pdd
+
+install-fish-completion:
+	install -m644 auto-completion/fish/pdd.fish -t $(PREFIX)/share/fish/vendor_completions.d
+
+install-zsh-completion:
+	cp pdd pdd.py
+	auto-completion/zsh/zsh_completion.py
+	install -m644 _pdd -t $(PREFIX)/share/zsh/site-functions
+
 uninstall:
 	rm -f $(BINDIR)/pdd
 	rm -f $(MANDIR)/pdd.1.gz
 	rm -rf $(DOCDIR)
+	rm -rf $(PREFIX)/share/bash-completion/compilations/pdd
+	rm -rf $(PREFIX)/share/fish/vendor_completions.d/pdd.fish
+	rm -rf $(PREFIX)/share/zsh/site-functions/_pdd
 
 check:
 	@python3 -m pytest test.py

--- a/auto-completion/zsh/zsh_completion.py
+++ b/auto-completion/zsh/zsh_completion.py
@@ -120,7 +120,7 @@ from os.path import dirname as dirn
 import sys
 from typing import Final, Tuple
 
-path = dirn(dirn(os.path.abspath(__file__)))
+path = dirn(dirn(dirn(os.path.abspath(__file__))))
 sys.path.insert(0, path)
 PACKAGE: Final = "pdd" if sys.argv[1:2] == [] else sys.argv[1]
 parser = __import__(PACKAGE).get_parser()


### PR DESCRIPTION
Any packager can `make install`.

For gentoo packagers, they can `make install-XXX-completion` according to `$USE`

```
❯ make -n install-all
install -m644 auto-completion/bash/pdd.bash /usr/local/share/bash-completion/compilations/pdd
cp pdd pdd.py
auto-completion/zsh/zsh_completion.py
install -m644 _pdd -t /usr/local/share/zsh/site-functions
install -m644 auto-completion/fish/pdd.fish -t /usr/local/share/fish/vendor_completions.d
install -m755 -d /usr/local/bin
install -m755 -d /usr/local/share/man/man1
install -m755 -d /usr/local/share/doc/pdd
gzip -c pdd.1 > pdd.1.gz
install -m755 pdd /usr/local/bin/pdd
install -m644 pdd.1.gz /usr/local/share/man/man1
install -m644 README.md /usr/local/share/doc/pdd
rm -f pdd.1.gz
```
