### PR TITLE
Pass -D flag to the install statements in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,27 +10,24 @@ all:
 install: install-bin install-completions
 
 install-bin:
-	install -m755 -d $(BINDIR)
-	install -m755 -d $(MANDIR)
-	install -m755 -d $(DOCDIR)
 	gzip -c pdd.1 > pdd.1.gz
-	install -m755 pdd $(BINDIR)/pdd
-	install -m644 pdd.1.gz $(MANDIR)
-	install -m644 README.md $(DOCDIR)
+	install -Dm755 pdd $(BINDIR)/pdd
+	install -Dm644 pdd.1.gz $(MANDIR)
+	install -Dm644 README.md $(DOCDIR)
 	rm -f pdd.1.gz
 
 install-completions: install-bash-completion install-zsh-completion install-fish-completion
 
 install-bash-completion:
-	install -m644 auto-completion/bash/pdd.bash $(PREFIX)/share/bash-completion/compilations/pdd
+	install -Dm644 auto-completion/bash/pdd.bash $(PREFIX)/share/bash-completion/compilations/pdd
 
 install-fish-completion:
-	install -m644 auto-completion/fish/pdd.fish -t $(PREFIX)/share/fish/vendor_completions.d
+	install -Dm644 auto-completion/fish/pdd.fish -t $(PREFIX)/share/fish/vendor_completions.d
 
 install-zsh-completion:
 	cp pdd pdd.py
 	auto-completion/zsh/zsh_completion.py
-	install -m644 _pdd -t $(PREFIX)/share/zsh/site-functions
+	install -Dm644 _pdd -t $(PREFIX)/share/zsh/site-functions
 
 uninstall:
 	rm -f $(BINDIR)/pdd


### PR DESCRIPTION
There's a `-D` flag which makes install statements in the Makefile more concise.
With this, we do not need to create directories with separate commands using
the `-d` flag.