### PR TITLE
Use DESTDIR + PREFIX in install-completions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 PREFIX ?= /usr/local
 BINDIR ?= $(DESTDIR)$(PREFIX)/bin
-MANDIR ?= $(DESTDIR)$(PREFIX)/share/man/man1
-DOCDIR ?= $(DESTDIR)$(PREFIX)/share/doc/pdd
+SHAREDIR ?= $(DESTDIR)$(PREFIX)/share
+MANDIR ?= $(SHAREDIR)/share/man/man1
+DOCDIR ?= $(SHAREDIR)/share/doc/pdd
 
 .PHONY: all install uninstall install-bin install-completions install-bash-completion install-zsh-completion install-fish-completion
 
@@ -19,23 +20,23 @@ install-bin:
 install-completions: install-bash-completion install-zsh-completion install-fish-completion
 
 install-bash-completion:
-	install -Dm644 auto-completion/bash/pdd.bash $(PREFIX)/share/bash-completion/completions/pdd
+	install -Dm644 auto-completion/bash/pdd.bash $(SHAREDIR)/bash-completion/completions/pdd
 
 install-fish-completion:
-	install -Dm644 auto-completion/fish/pdd.fish -t $(PREFIX)/share/fish/vendor_completions.d
+	install -Dm644 auto-completion/fish/pdd.fish -t $(SHAREDIR)/fish/vendor_completions.d
 
 install-zsh-completion:
 	cp pdd pdd.py
 	auto-completion/zsh/zsh_completion.py
-	install -Dm644 _pdd -t $(PREFIX)/share/zsh/site-functions
+	install -Dm644 _pdd -t $(SHAREDIR)/zsh/site-functions
 
 uninstall:
 	rm -f $(BINDIR)/pdd
 	rm -f $(MANDIR)/pdd.1.gz
 	rm -rf $(DOCDIR)
-	rm -rf $(PREFIX)/share/bash-completion/completions/pdd
-	rm -rf $(PREFIX)/share/fish/vendor_completions.d/pdd.fish
-	rm -rf $(PREFIX)/share/zsh/site-functions/_pdd
+	rm -rf $(SHAREDIR)/bash-completion/completions/pdd
+	rm -rf $(SHAREDIR)/fish/vendor_completions.d/pdd.fish
+	rm -rf $(SHAREDIR)/zsh/site-functions/_pdd
 
 check:
 	@python3 -m pytest test.py

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 PREFIX ?= /usr/local
 BINDIR ?= $(DESTDIR)$(PREFIX)/bin
 SHAREDIR ?= $(DESTDIR)$(PREFIX)/share
-MANDIR ?= $(SHAREDIR)/share/man/man1
-DOCDIR ?= $(SHAREDIR)/share/doc/pdd
+MANDIR ?= $(SHAREDIR)/man/man1
+DOCDIR ?= $(SHAREDIR)/doc/pdd
 
 .PHONY: all install uninstall install-bin install-completions install-bash-completion install-zsh-completion install-fish-completion
 


### PR DESCRIPTION
Completion installation paths do not use the DESTDIR variable. Therefore, they are being installed in a different folder.