### PR TITLE
Chore: Add _pdd file to . gitignore 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pdd.egg-info
 dist/
 build/
 pdd.py
+_pdd


### PR DESCRIPTION
The `_pdd` file, generated by Makefile, is missing from .gitignore